### PR TITLE
cors mapping config 설정 추가

### DIFF
--- a/src/main/java/org/localdevelopers/payfinder/config/WebConfig.java
+++ b/src/main/java/org/localdevelopers/payfinder/config/WebConfig.java
@@ -2,14 +2,14 @@ package org.localdevelopers.payfinder.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@Configuration
 public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost");
+                .allowedOrigins("http://localhost:3000", "http://payfinder.site");
     }
 }


### PR DESCRIPTION
- 빈 설정되도록 @Configuration 추가
- ui static host (http://payfinder.site) 허용 origin에 추가